### PR TITLE
Fix config and add missing health modules

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,14 @@ keyring_service = "minimal-kernel"
 auto_save_keyring = true
 # 密钥派生轮数
 key_derivation_rounds = 100000
+# 是否使用系统 keyring（macOS Keychain / Windows Credential Manager / Linux Secret Service）
+use_keyring = true
+# keyring 访问超时时间（秒）- 给用户足够时间输入系统密码
+keyring_timeout_secs = 30
+# 私钥文件路径（当 use_keyring = false 时使用）
+# private_key_file = "~/.minimal-kernel/identity.key"
+# 是否允许从环境变量 MINIMAL_KERNEL_PRIVATE_KEY 加载私钥
+allow_env_key = true
 
 [message_bus]
 # 消息缓冲区大小
@@ -53,12 +61,3 @@ color = true
 # 是否启用详细模式
 verbose = false
 
-[identity]
-# 是否使用系统 keyring（macOS Keychain / Windows Credential Manager / Linux Secret Service）
-use_keyring = true
-# keyring 访问超时时间（秒）- 给用户足够时间输入系统密码
-keyring_timeout_secs = 30
-# 私钥文件路径（当 use_keyring = false 时使用）
-# private_key_file = "~/.minimal-kernel/identity.key"
-# 是否允许从环境变量 MINIMAL_KERNEL_PRIVATE_KEY 加载私钥
-allow_env_key = true

--- a/src/health/aggregator.rs
+++ b/src/health/aggregator.rs
@@ -1,0 +1,25 @@
+use super::fhir::Observation;
+
+/// Very small in-memory aggregator for health observations
+#[derive(Default)]
+pub struct HealthDataAggregator {
+    observations: Vec<Observation>,
+}
+
+impl HealthDataAggregator {
+    /// Create new empty aggregator
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an observation to the aggregator
+    pub fn add_observation(&mut self, obs: Observation) {
+        self.observations.push(obs);
+    }
+
+    /// Retrieve all stored observations
+    pub fn observations(&self) -> &[Observation] {
+        &self.observations
+    }
+}
+

--- a/src/health/fhir.rs
+++ b/src/health/fhir.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// FHIR Observation status (simplified)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ObservationStatus {
+    Preliminary,
+    Final,
+    Amended,
+    Cancelled,
+}
+
+/// FHIR CodeableConcept (very small subset)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodeableConcept {
+    pub code: String,
+    pub display: Option<String>,
+}
+
+/// FHIR Quantity (value with unit)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Quantity {
+    pub value: f64,
+    pub unit: String,
+}
+
+/// Simplified FHIR Observation
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Observation {
+    pub id: Option<String>,
+    pub status: ObservationStatus,
+    pub code: CodeableConcept,
+    pub value: Option<Quantity>,
+}
+

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -251,11 +251,6 @@ impl Kernel {
         &self.message_bus_handle
     }
     
-    /// 获取存储实例
-    pub fn get_storage(&self) -> &Arc<Storage> {
-        &self.storage
-    }
-    
     /// 获取插件加载器的可变引用
     pub fn get_plugin_loader_mut(&mut self) -> &mut PluginLoader {
         &mut self.plugin_loader


### PR DESCRIPTION
## Summary
- remove duplicate `get_storage` method
- consolidate `[identity]` section in `config.toml`
- introduce basic health module implementation

## Testing
- `SQLX_OFFLINE=true cargo check` *(fails: no cached data for queries)*

------
https://chatgpt.com/codex/tasks/task_e_688c88b3d6688332b663febc482c858c